### PR TITLE
Fix build on Ubuntu 20.04

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,11 +13,12 @@ m4_include([version.m4])
 AC_PREREQ([2.61])
 AC_INIT([libmemcached],VERSION_NUMBER,[http://libmemcached.org/])
 
+AC_CONFIG_AUX_DIR([build-aux])
+
 # Setup the compilers early on
 AC_PROG_CC([cc gcc clang])
 AC_PROG_CXX([c++ g++ clang++])
 
-AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
In short: autoconf failed to generated configure script that could find
helper scripts. See description in memcached bug [1], libmemcached bug
[2] and description of AC_CONFIG_AUX_DIR in Automake documentation [3].

1. https://github.com/tarantool/memcached/issues/80
2. https://bugs.launchpad.net/libmemcached/+bug/1803922
3. https://www.gnu.org/software/automake/manual/html_node/Optional.html